### PR TITLE
Authentication/add test error sign in

### DIFF
--- a/app/controllers/users_controllers.rb
+++ b/app/controllers/users_controllers.rb
@@ -1,0 +1,4 @@
+class UsersController < ApplicationController
+  def index
+  end
+end

--- a/app/javascript/packs/application.js
+++ b/app/javascript/packs/application.js
@@ -3,7 +3,7 @@ import Turbolinks from "turbolinks"
 import "channels"
 
 Rails.start()
-Turbolinks.start()
+//Turbolinks.start()
 
 import 'jquery'
 import 'popper.js'

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -10,26 +10,31 @@
   <div class="container">
     <div class="d-flex justify-content-center col-sm-12 col-md-10 col-lg">
       <div class="col-lg-5">
+
         <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
           <%= render "devise/shared/error_messages", resource: resource %>
 
-          <div class="form-row form-group w-100">
-            <%= f.label :email %>
-            <%= f.email_field :email,
-                               autofocus: true,
-                               autocomplete: "email",
-                               class: "rounded-bottom border-bottom-2 form-control",
-                               placeholder: t('placeholder.type_email')
-            %>
+          <div class="form-row">
+            <div class="form-group w-100">
+              <%= f.label :email %>
+              <%= f.email_field :email,
+                                 autofocus: true,
+                                 autocomplete: "email",
+                                 class: "rounded-bottom border-bottom-5 form-control",
+                                 placeholder: t('placeholder.type_email')
+              %>
+            </div>
           </div>
 
-          <div class="form-row form-group w-100">
-            <%= f.label :password %>
-            <%= f.password_field :password,
-                                  autocomplete: "current-password",
-                                  class: "rounded-bottom border-bottom-5 form-control",
-                                  placeholder: t('placeholder.type_password')
-            %>
+          <div class="form-row">
+            <div class="form-group w-100">
+              <%= f.label :password %>
+              <%= f.password_field :password,
+                                    autocomplete: "current-password",
+                                    class: "rounded-bottom border-bottom-5 form-control",
+                                    placeholder: t('placeholder.type_password')
+              %>
+            </div>
           </div>
 
           <div class="form-row form-group w-100">

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -13,6 +13,10 @@
         <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
           <%= render "devise/shared/error_messages", resource: resource %>
 
+          <% flash.each do |attr, mensagem| %>
+            <%= content_tag :div, mensagem %>
+          <% end %>
+
           <div class="form-row form-group w-100">
             <%= f.label :email %>
             <%= f.email_field :email,
@@ -61,7 +65,6 @@
               </p>
             </div>
           </div>
-
         <% end %>
       </div>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,7 @@
 Rails.application.routes.draw do
   devise_for :users
-	root to: "home#index"
+
+	root "home#index"
 
 	resources :promotions do
     post 'generate_coupon', on: :member

--- a/config/webpack/environment.js
+++ b/config/webpack/environment.js
@@ -1,7 +1,7 @@
 const { environment } = require('@rails/webpacker')
 
 const webpack = require("webpack");
-environment.plugins.append(
+environment.plugins.prepend(
   "Provide",
   new webpack.ProvidePlugin({
     $: "jquery",

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -10,7 +10,7 @@ default: &default
 
   # Additional paths webpack should lookup modules
   # ['app/assets', 'engine/foo/app/assets']
-  additional_paths: []
+  resolved_paths: ['app/assets']
 
   # Reload manifest.json on all requests so we reload latest compiled packs
   cache_manifest: false

--- a/test/system/user/authentication/authentication_test.rb
+++ b/test/system/user/authentication/authentication_test.rb
@@ -110,6 +110,21 @@ class AuthenticationTest < ApplicationSystemTestCase
     assert_link 'Sair'
   end
 
+  test 'user can not sign_in with fields blank' do
+    user = User.create!(email: 'mclovin@iugu.com.br', password: '12345678')
+
+    visit new_user_session_path
+
+    fill_in 'Email', with: ''
+    fill_in 'Senha', with: ''
+
+    click_on 'Confirmar'
+
+    flunk('Esse teste não está renderizando os erros por meio do devise')
+    # assert_text 'Email não pode ficar em branco'
+    # assert_text 'Senha não pode ficar em branco'
+  end
+
   test 'user sign_out' do
 
     login_user


### PR DESCRIPTION
* Adicionando testes de error em de autenticação de sign_in
* O devise não está renderizando o erro, `resources.error.empty?` é verdadeiro em casos em que o campos são inválidos.
* Desabilitando o turbolink.
* Consertando um bug de tela em sign_up.