### PR TITLE
Corrigindo erro em teste de validação customizada future_date

### DIFF
--- a/app/models/promotion.rb
+++ b/app/models/promotion.rb
@@ -10,7 +10,7 @@ class Promotion < ApplicationRecord
                    uniqueness: true
   validates :discount_rate, presence: true
   validates :coupon_quantity, presence: true
-  validates :expiration_date, presence: true
+  validates :expiration_date, presence: true, future_date: true
 
   def generated_coupons!
     return if coupons?

--- a/app/validators/future_date_validator.rb
+++ b/app/validators/future_date_validator.rb
@@ -1,0 +1,8 @@
+class FutureDateValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    if value.present? && value <= Time.zone.now
+      message = options[:message] || :future_date
+      record.errors.add(attribute, message)
+    end
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,6 +22,8 @@ Bundler.require(*Rails.groups)
 module PromotionSystem
   class Application < Rails::Application
     config.load_defaults 6.1
-    config.time_zone = "Brasilia"
+    config.i18n.load_path += Dir[Rails.root.join('config/locales/**/*.{rb,yml}')]
+    config.i18n.default_locale = :'pt-BR'
+
   end
 end

--- a/config/locales/models/promotion/pt-BR.yml
+++ b/config/locales/models/promotion/pt-BR.yml
@@ -16,6 +16,7 @@ pt-BR:
     errors:
       messages:
         taken: deve ser único
+        future_date: Data inválida - data tem de ser futura
   promotions:
     index:
       promotions_empty: Nenhuma promoção cadastrada

--- a/test/system/promotions/promotions_test.rb
+++ b/test/system/promotions/promotions_test.rb
@@ -10,12 +10,12 @@ class PromotionsTest < ApplicationSystemTestCase
 
     Promotion.create!(name: 'Natal', description: 'Promoção de Natal',
                       code: 'NATAL10', discount_rate: 10, coupon_quantity: 100,
-                      expiration_date: '22/12/2033', user: user)
+                      expiration_date: Time.zone.tomorrow, user: user)
 
     Promotion.create!(name: 'Cyber Monday', coupon_quantity: 100,
                       description: 'Promoção de Cyber Monday',
                       code: 'CYBER15', discount_rate: 15,
-                      expiration_date: '22/12/2033', user: user)
+                      expiration_date: Time.zone.tomorrow, user: user)
 
     visit root_path
     click_on 'Promoções'
@@ -35,12 +35,12 @@ class PromotionsTest < ApplicationSystemTestCase
     Promotion.create!(name: 'Natal', coupon_quantity: 100,
                       description: 'Promoção de Natal',
                       code: 'NATAL10', discount_rate: 10,
-                      expiration_date: '22/12/2033', user: user)
+                      expiration_date: Time.zone.tomorrow, user: user)
 
     Promotion.create!(name: 'Cyber Monday', coupon_quantity: 90,
                       description: 'Promoção de Cyber Monday',
                       code: 'CYBER15', discount_rate: 15,
-                      expiration_date: '22/12/2033', user: user)
+                      expiration_date: Time.zone.tomorrow, user: user)
 
     visit promotions_path
 
@@ -50,7 +50,7 @@ class PromotionsTest < ApplicationSystemTestCase
     assert_text 'Promoção de Cyber Monday'
     assert_text '15,00%'
     assert_text 'CYBER15'
-    assert_text '22/12/2033'
+    assert_text I18n.l(Date.tomorrow, format: '%d/%m/%Y')
     assert_text '90'
   end
 
@@ -78,7 +78,7 @@ class PromotionsTest < ApplicationSystemTestCase
 
     Promotion.create!(name: 'Natal', description: 'Promoção de Natal',
                       code: 'NATAL10', discount_rate: 10, coupon_quantity: 100,
-                      expiration_date: '22/12/2033', user: user)
+                      expiration_date: Time.zone.tomorrow, user: user)
 
     visit root_path
 
@@ -94,7 +94,7 @@ class PromotionsTest < ApplicationSystemTestCase
     promotion = Promotion.create!(name: 'Natal', coupon_quantity: 100,
                                   description: 'Promoção de Natal',
                                   code: 'NATAL10', discount_rate: 10,
-                                  expiration_date: '22/12/2033', user: user)
+                                  expiration_date: Time.zone.tomorrow, user: user)
 
     visit promotion_path promotion
 
@@ -114,7 +114,7 @@ class PromotionsTest < ApplicationSystemTestCase
     promotion = Promotion.create!(name: 'Natal', coupon_quantity: 100,
                               description: 'Promoção de Natal',
                               code: 'NATAL10', discount_rate: 10,
-                              expiration_date: '22/12/2033', user: user)
+                              expiration_date: Time.zone.tomorrow, user: user)
 
     visit promotion_path promotion
 
@@ -135,7 +135,7 @@ class PromotionsTest < ApplicationSystemTestCase
     fill_in 'Código', with: 'CYBER15'
     fill_in 'Desconto', with: '15'
     fill_in 'Quantidade de Coupons', with: '90'
-    fill_in 'Data de término', with: I18n.l(Date.today, format: '%m-%d-%Y')
+    fill_in 'Data de término', with: Time.zone.tomorrow
     click_on 'Criar Promoção'
 
     assert_text 'Promoção criada com sucesso.'
@@ -143,9 +143,27 @@ class PromotionsTest < ApplicationSystemTestCase
     assert_text 'Promoção de Cyber Monday'
     assert_text '15,00%'
     assert_text 'CYBER15'
-    assert_text  I18n.l(Date.today, format: '%d/%m/%Y')
+    assert_text  I18n.l(Date.tomorrow, format: '%d/%m/%Y')
     assert_text '90'
     assert_link 'Voltar'
+  end
+
+  test 'expiration_date need to be valid' do
+    login_user
+
+    visit new_promotion_path
+
+    assert_text 'Criar Promoção'
+
+    fill_in 'Nome', with: 'Cyber Monday'
+    fill_in 'Descrição', with: 'Promoção de Cyber Monday'
+    fill_in 'Código', with: 'CYBER15'
+    fill_in 'Desconto', with: '15'
+    fill_in 'Quantidade de Coupons', with: '90'
+    fill_in 'Data de término', with: Time.zone.yesterday
+    click_on 'Criar Promoção'
+
+    assert_text 'Data inválida - data tem de ser futura'
   end
 
   test 'create and attributes cannot be blank' do
@@ -163,7 +181,7 @@ class PromotionsTest < ApplicationSystemTestCase
 
     Promotion.create!(name: 'Natal', description: 'Promoção de Natal',
                       code: 'NATAL10', discount_rate: 10, coupon_quantity: 100,
-                      expiration_date: '22/12/2033', user: user)
+                      expiration_date: Time.zone.tomorrow, user: user)
 
     visit new_promotion_path
 
@@ -179,7 +197,7 @@ class PromotionsTest < ApplicationSystemTestCase
 
     promotion = Promotion.create!(name: 'Independência', description: 'Promoção da independência.',
                                   code: 'Free22', discount_rate: 40, coupon_quantity: 200,
-                                  expiration_date: I18n.l(Date.today, format: '%Y-%m-%d'), user: user
+                                  expiration_date: Time.zone.tomorrow, user: user
                                   )
 
     visit promotion_path(promotion)
@@ -193,11 +211,11 @@ class PromotionsTest < ApplicationSystemTestCase
     assert_selector "form input[type=text][value='Free22']"
     assert_selector "form input[type=number][value='40.0']"
     assert_selector "form input[type=number][value='200']"
-    assert_selector "form input[type=date][value='#{I18n.l(Date.today, format: '%Y-%m-%d')}']"
+    assert_selector "form input[type=date][value='#{I18n.l(Date.tomorrow, format: '%Y-%m-%d')}']"
 
     fill_in 'Nome', with: 'Páscoa'
     fill_in 'Descrição', with: 'Ovo de Páscoa'
-    fill_in 'Data de término', with: I18n.l(Date.today.tomorrow, format: '%m-%d-%Y')
+    fill_in 'Data de término', with: I18n.l(Date.tomorrow + 2.day, format: '%m-%d-%Y')
 
     click_on 'Atualizar Promoção'
 
@@ -207,7 +225,7 @@ class PromotionsTest < ApplicationSystemTestCase
     assert_text 'Free22'
     assert_text '40'
     assert_text '200'
-    assert_text I18n.l(Date.today.tomorrow, format: '%d/%m/%Y')
+    assert_text I18n.l(Date.tomorrow + 2.day, format: '%d/%m/%Y')
   end
 
   test 'edit promotion cannot be blank' do
@@ -215,7 +233,7 @@ class PromotionsTest < ApplicationSystemTestCase
 
     promotion = Promotion.create!(name: 'Independência', description: 'Promoção da independência.',
                                   code: 'Free22', discount_rate: 40, coupon_quantity: 200,
-                                  expiration_date: I18n.l(Date.today, format: '%Y-%m-%d'), user: user
+                                  expiration_date: Time.zone.tomorrow, user: user
                                   )
 
     visit edit_promotion_path promotion
@@ -237,7 +255,7 @@ class PromotionsTest < ApplicationSystemTestCase
 
     promotion = Promotion.create!(name: 'Independência', description: 'Promoção da independência.',
                                   code: 'Free22', discount_rate: 40, coupon_quantity: 200,
-                                  expiration_date: I18n.l(Date.today, format: '%Y-%m-%d'), user: user
+                                  expiration_date: Time.zone.tomorrow, user: user
                                   )
     promotion.generated_coupons!
 
@@ -257,7 +275,7 @@ class PromotionsTest < ApplicationSystemTestCase
 
     Promotion.create!(name: 'Natal', description: 'Promoção de Natal',
                       code: 'NATAL10', discount_rate: 10,
-                      coupon_quantity: 100, expiration_date: '22/12/2033', user: user)
+                      coupon_quantity: 100, expiration_date: Time.zone.tomorrow, user: user)
 
     visit promotions_path
 
@@ -274,11 +292,11 @@ class PromotionsTest < ApplicationSystemTestCase
 
     Promotion.create!(name: 'Natal', description: 'Promoção de Natal',
                       code: 'NATAL10', discount_rate: 10, coupon_quantity: 100,
-                      expiration_date: '22/12/2033', user: user)
+                      expiration_date: Time.zone.tomorrow, user: user)
     Promotion.create!(name: 'Cyber Monday', coupon_quantity: 90,
                       description: 'Promoção de Cyber Monday',
                       code: 'CYBER15', discount_rate: 15,
-                      expiration_date: '22/12/2033', user: user)
+                      expiration_date: Time.zone.tomorrow, user: user)
 
     visit promotions_path
 
@@ -305,7 +323,7 @@ class PromotionsTest < ApplicationSystemTestCase
     promotion = Promotion.create!(name: 'Cyber Monday', coupon_quantity: 90,
                   description: 'Promoção de Cyber Monday',
                   code: 'CYBER15', discount_rate: 15,
-                  expiration_date: '22/12/2033', user: user)
+                  expiration_date: Time.zone.tomorrow, user: user)
 
     visit promotion_path(promotion)
 
@@ -317,7 +335,7 @@ class PromotionsTest < ApplicationSystemTestCase
 
     promotion = Promotion.create!(name: 'Independência', description: 'Promoção da independência.',
                                   code: 'Free22', discount_rate: 40, coupon_quantity: 200,
-                                  expiration_date: I18n.l(Date.today, format: '%Y-%m-%d'), user: user
+                                  expiration_date: Time.zone.tomorrow, user: user
                                   )
 
     login_user
@@ -334,7 +352,7 @@ class PromotionsTest < ApplicationSystemTestCase
 
     promotion = Promotion.create!(name: 'Independência', description: 'Promoção da independência.',
                                   code: 'Free22', discount_rate: 40, coupon_quantity: 200,
-                                  expiration_date: I18n.l(Date.today, format: '%Y-%m-%d'), user: user)
+                                  expiration_date: Time.zone.tomorrow, user: user)
 
     visit promotions_path
     assert_text 'Aguardando Aprovação!'

--- a/test/validators/future_date_validator_test.rb
+++ b/test/validators/future_date_validator_test.rb
@@ -1,0 +1,46 @@
+require 'test_helper'
+
+class Validatable
+  include ActiveModel::Validations
+  attr_accessor :expiration_date
+
+  validates :expiration_date, future_date: true
+end
+
+class FutureDateValidatorTest < ActiveSupport::TestCase
+  def setup
+    @obj = Validatable.new
+  end
+
+  test 'when the date is before the current date should be invalid' do
+    @obj.expiration_date = 1.day.ago
+
+    refute @obj.valid?
+  end
+
+  test 'when the date is before the current date adds an error' do
+    @obj.expiration_date = 1.day.ago
+
+    @obj.valid?
+    assert_includes @obj.errors.attribute_names, :expiration_date
+  end
+
+  test 'when the date is igual the current date should be invalid' do
+    @obj.expiration_date = Time.zone.now
+
+    refute @obj.valid?
+  end
+
+  test 'when the date is igual the current date adds an error' do
+    @obj.expiration_date = Time.zone.now
+    @obj.valid?
+
+    assert_includes @obj.errors.attribute_names, :expiration_date
+  end
+
+  test 'should be valid' do
+    @obj.expiration_date = Time.zone.tomorrow + 1.day
+
+    assert @obj.valid?
+  end
+end

--- a/test/validators/future_date_validator_test.rb
+++ b/test/validators/future_date_validator_test.rb
@@ -1,6 +1,6 @@
 require 'test_helper'
 
-class Validatable
+class FutureDateValidatable
   include ActiveModel::Validations
   attr_accessor :expiration_date
 
@@ -9,7 +9,7 @@ end
 
 class FutureDateValidatorTest < ActiveSupport::TestCase
   def setup
-    @obj = Validatable.new
+    @obj = FutureDateValidatable.new
   end
 
   test 'when the date is before the current date should be invalid' do


### PR DESCRIPTION
O teste da validação customizada :future_date estava com o nome de classe igual ao nome de classe de outro teste apenas modificar seu nome consertou o conflito dado ao executar os testes. 
O que ocorria é que os atributos da outra classe de nome igual eram adicionados ao teste de :future_date, assim o teste que deveria passar não passava.

Outra solução:
```
include ActiveModel::Validations
Validatable.clear_validators!
